### PR TITLE
Nodos arreglados tras revisión de cleon

### DIFF
--- a/Game/Game/src/components/ButtonComponent.h
+++ b/Game/Game/src/components/ButtonComponent.h
@@ -3,13 +3,11 @@
 #include "Transform.h"
 #include "../sdlutils/InputHandler.h"
 #include "../components/Animator.h"
-#include "../GameObjects/UI/Button.h"
 
 // Estados representados por números
 enum State { OnOut = 0, OnOver, OnClick };
 
 class SDLApplication;
-typedef void CallBack();
 
 class ButtonComponent : public Component {
 
@@ -18,7 +16,7 @@ protected:
 	SDLApplication* game;
 	
 	// Función a realizar
-	CallBack* function;
+	CallBack function;
 
 	// Estado del botón
 	int state;
@@ -33,7 +31,7 @@ protected:
 
 public:
 	static const int id = _BUTTON;
-	ButtonComponent(CallBack* _f, SDLApplication* _g, GameObject* _frame = nullptr) :
+	ButtonComponent(CallBack _f, SDLApplication* _g, GameObject* _frame = nullptr) :
 		Component(), state(0), function(_f), game(_g), frame(_frame), tr(nullptr), animButton(nullptr), animFrame(nullptr) {}
 
 	virtual void update();

--- a/Game/Game/src/components/NodeButtonComponent.cpp
+++ b/Game/Game/src/components/NodeButtonComponent.cpp
@@ -1,14 +1,14 @@
 #include "NodeButtonComponent.h"
 
 // Constructora que recibe un iterador al tipo de  batalla, un callback y un puntero al estado del nodo
-NodeButtonComponent::NodeButtonComponent(list<battleType>::iterator* _it, CallBack* _f, nodeState const* _nState) :
-ButtonComponent(_f, nullptr), it(_it), nState(_nState) {}
+NodeButtonComponent::NodeButtonComponent(CallBack _f, nodeState const& _nState) :
+ButtonComponent(_f, nullptr), nState(_nState) {}
 
 // Actualiza el estado del botón
 void NodeButtonComponent::update() {
 	ButtonComponent::update();
-	if (*nState == _LOCKED_NODE) state = OnLocked;
-	else if (*nState == _COMPLETED_NODE) state = OnCompleted;
+	if (nState == _LOCKED_NODE) state = OnLocked;
+	else if (nState == _COMPLETED_NODE) state = OnCompleted;
 }
 
 // Actualiza la animación del botón según el estado
@@ -25,7 +25,6 @@ void NodeButtonComponent::updateAnimation() {
 // Ejecuta el callback del botón si este está disponible
 void NodeButtonComponent::onClick() {
 	if (!(state == OnLocked || state == OnCompleted)) {
-		BattleNode::lastType = it;
 		ButtonComponent::onClick();
 	}
 }

--- a/Game/Game/src/components/NodeButtonComponent.h
+++ b/Game/Game/src/components/NodeButtonComponent.h
@@ -15,11 +15,10 @@ private:
 		OnLocked,
 		OnCompleted };
 
-	list<battleType>::iterator* it;
-	nodeState const* nState;
+	nodeState const& nState;
 public:
 	// Constructora que recibe un iterador al tipo de  batalla, un callback y un puntero al estado del nodo
-	NodeButtonComponent(list<battleType>::iterator* _it, CallBack* _f, nodeState const* _nState);
+	NodeButtonComponent(CallBack _f, nodeState const& _nState);
 	
 	// Actualiza el estado del botón
 	virtual void update();

--- a/Game/Game/src/components/NodeButtonComponent.h
+++ b/Game/Game/src/components/NodeButtonComponent.h
@@ -9,7 +9,7 @@ class NodeButtonComponent : public ButtonComponent {
 private:
 	// Estados representados por números
 	enum State {
-		OnOut = 0,
+		OnOut,
 		OnOver,
 		OnClick, 
 		OnLocked,

--- a/Game/Game/src/components/ecs.h
+++ b/Game/Game/src/components/ecs.h
@@ -26,4 +26,9 @@ enum cmpId : cmpId_type {
 };
 constexpr cmpId_type maxComponentId = _LAST_CMP_ID;
 
+
+#include <functional>
+// Tipo de función que devuelve y recibe void, funciona también con funciones lambda con capturas
+using CallBack = std::function<void(void)>;
+
 #endif // !ECS_H_

--- a/Game/Game/src/gameObjects/NodeButton.cpp
+++ b/Game/Game/src/gameObjects/NodeButton.cpp
@@ -1,10 +1,10 @@
 #include "NodeButton.h"
 
-void NodeButton::initGameObject(vector<Node*>::const_iterator nodeIt, CallBack* _cb) {
+void NodeButton::initGameObject(vector<Node*>::const_iterator nodeIt, CallBack _cb) {
 
 	addComponent<Transform>((*nodeIt)->getPosition(), VECTOR_ZERO, NODE_WIDTH, NODE_HEIGHT);
 	Animator* animator = addComponent<Animator>(SDLApplication::getTexture((*nodeIt)->getTextureKey()), NODE_FRAME_WIDTH, NODE_FRAME_HEIGHT, NODE_FRAME_ROWS, NODE_FRAME_COLUMNS);
-	addComponent<NodeButtonComponent>((*nodeIt)->getIt(), _cb, (*nodeIt)->getState());
+	addComponent<NodeButtonComponent>(_cb, (*nodeIt)->getState());
 
 	animator->createAnim(ONOUT, NODE_BUTTON_ONOUT_START_FRAME, NODE_BUTTON_ONOUT_END_FRAME, ONCLICK_ONOUT_SPEED, -1);
 	animator->createAnim(ONOVER, NODE_BUTTON_ONOVER_START_FRAME, NODE_BUTTON_ONOVER_END_FRAME, ONOVER_SPEED, -1);

--- a/Game/Game/src/gameObjects/NodeButton.h
+++ b/Game/Game/src/gameObjects/NodeButton.h
@@ -7,7 +7,7 @@
 class NodeButton : public GameObject {
 public:
 	// Añade los componentes al botón y crea sus animaciones
-	virtual void initGameObject(vector<Node*>::const_iterator nodeIt, CallBack* _cb);
+	virtual void initGameObject(vector<Node*>::const_iterator nodeIt, CallBack _cb);
 };
 
 #endif // !NODEBUTTON_H_

--- a/Game/Game/src/gameObjects/UI/Button.cpp
+++ b/Game/Game/src/gameObjects/UI/Button.cpp
@@ -2,7 +2,7 @@
 #include "../../core/SDLApplication.h"
 
 // Añade los componentes al botón y crea sus animaciones
-void Button::initGameObject(CallBack* _cb, SDLApplication* game, Vector2D _pos, string key, int _w, int _h, int _fw, int _fh, int _r, int _c, GameObject* _frame) {
+void Button::initGameObject(CallBack _cb, SDLApplication* game, Vector2D _pos, string key, int _w, int _h, int _fw, int _fh, int _r, int _c, GameObject* _frame) {
 	// Transform
 	addComponent<Transform>(_pos, VECTOR_ZERO, _w, _h);
 

--- a/Game/Game/src/gameObjects/UI/Button.h
+++ b/Game/Game/src/gameObjects/UI/Button.h
@@ -6,14 +6,12 @@
 #include "../../components/ButtonComponent.h"
 #include "../../components/Animator.h"
 
-class SDLApplication;
-typedef void CallBack(); // cleon says: igual esto tendría que estar en un .h genérico o algo así? quién sabe.
 class Button : public GameObject {
 private:
 public:
 	// Añade los componentes al botón y crea sus animaciones
 	// // cleon says:  11 parámetros == 11 gatitos que sufren
-	virtual void initGameObject(CallBack* _cb, SDLApplication* game, Vector2D _pos, string key, int _w, int _h, int _fw, int _fh, int _r, int _c, GameObject* _frame = nullptr);
+	virtual void initGameObject(CallBack _cb, SDLApplication* game, Vector2D _pos, string key, int _w, int _h, int _fw, int _fh, int _r, int _c, GameObject* _frame = nullptr);
 
 	// Crear animaciones
 	void createButtonAnimations(Animator* animator);

--- a/Game/Game/src/node/BattleNode.cpp
+++ b/Game/Game/src/node/BattleNode.cpp
@@ -1,13 +1,10 @@
 #include "BattleNode.h"
-#include "../core/PlayerData.h"
+#include "../core/SDLApplication.h"
 
-list<battleType> BattleNode::battleTypes = list<battleType>();
-list<battleType>::iterator* BattleNode::lastType = nullptr;
+BattleNode::BattleNode(Vector2D const& pos) : Node(BATTLE_NODE_TEXTURE_KEY, pos), type(battleType(SDLUtils::instance()->rand().nextInt(0, 3))) {}
 
-BattleNode::BattleNode(Vector2D const& pos) : Node(BATTLE_NODE_TEXTURE_KEY, pos), type(battleTypes.insert(battleTypes.end(), battleType(SDLUtils::instance()->rand().nextInt() % 3))) {}
-
-CallBack* BattleNode::loadNode() const {
-	return []() { 
-		SDLApplication::newScene<BattleScene>(*(*lastType));
+CallBack BattleNode::loadNode() const {
+	return [&]() { 
+		SDLApplication::newScene<BattleScene>(type);
 	};
 }

--- a/Game/Game/src/node/BattleNode.cpp
+++ b/Game/Game/src/node/BattleNode.cpp
@@ -1,8 +1,10 @@
 #include "BattleNode.h"
 #include "../core/SDLApplication.h"
 
+// Constructora, recibe posición del nodo en el mapa
 BattleNode::BattleNode(Vector2D const& pos) : Node(BATTLE_NODE_TEXTURE_KEY, pos), type(battleType(SDLUtils::instance()->rand().nextInt(0, 3))) {}
 
+// Devuelve un CallBack que abre la escena de batalla del tipo del nodo
 CallBack BattleNode::loadNode() const {
 	return [&]() { 
 		SDLApplication::newScene<BattleScene>(type);

--- a/Game/Game/src/node/BattleNode.h
+++ b/Game/Game/src/node/BattleNode.h
@@ -17,22 +17,15 @@ enum battleType {
 
 class BattleNode : public Node {
 	friend Node;
-	friend NodeButtonComponent;
 private:
-
-	static list<battleType>::iterator* lastType;
-	static list<battleType> battleTypes;
-	list<battleType>::iterator type;
-
+	battleType type;
 
 	//battleType type;
 	BattleNode(Vector2D const& pos);
 public:
-	virtual CallBack* loadNode() const;
-	// cleon says: MAAAAAALLLLLLLLLLLLLLLLLLLLL. igual a veces sí que es bueno tener miedo.
-	virtual list<battleType>::iterator* getIt() { return &type; }
+	virtual CallBack loadNode() const;
 	// Devuelve la clave de la textura del nodo
-	inline virtual string getTextureKey() const { return Node::getTextureKey() + to_string((int)*type); }
+	inline virtual string getTextureKey() const { return Node::getTextureKey() + to_string((int)type); }
 };
 
 #endif // !BATTLENODE_H_

--- a/Game/Game/src/node/BattleNode.h
+++ b/Game/Game/src/node/BattleNode.h
@@ -10,7 +10,7 @@ class BattleScene;
 class NodeButtonComponent;
 
 enum battleType {
-	_PASTBATTLE = 0,
+	_PASTBATTLE,
 	_PRESENTBATTLE,
 	_FUTUREBATTLE
 };
@@ -18,11 +18,13 @@ enum battleType {
 class BattleNode : public Node {
 	friend Node;
 private:
+	// Tipo de batalla del nodo, aleatoria para cada instancia
 	battleType type;
 
-	//battleType type;
+	// Constructora, recibe posición del nodo en el mapa
 	BattleNode(Vector2D const& pos);
 public:
+	// Devuelve un CallBack que abre la escena de batalla del tipo del nodo
 	virtual CallBack loadNode() const;
 	// Devuelve la clave de la textura del nodo
 	inline virtual string getTextureKey() const { return Node::getTextureKey() + to_string((int)type); }

--- a/Game/Game/src/node/ChestNode.cpp
+++ b/Game/Game/src/node/ChestNode.cpp
@@ -1,8 +1,10 @@
 #include "ChestNode.h"
 #include "../core/SDLApplication.h"
 
+// Constructora, recibe posición del nodo en el mapa
 ChestNode::ChestNode(Vector2D const& pos) : Node(CHEST_NODE_TEXTURE_KEY, pos) {}
 
+// Devuelve un CallBack que abre la escena de cofre
 CallBack ChestNode::loadNode() const{
 	return []() {
 		SDLApplication::newScene<ChestScene>();

--- a/Game/Game/src/node/ChestNode.cpp
+++ b/Game/Game/src/node/ChestNode.cpp
@@ -1,7 +1,10 @@
 #include "ChestNode.h"
+#include "../core/SDLApplication.h"
 
 ChestNode::ChestNode(Vector2D const& pos) : Node(CHEST_NODE_TEXTURE_KEY, pos) {}
 
-CallBack* ChestNode::loadNode() const{
-	return MapScene::chest;
+CallBack ChestNode::loadNode() const{
+	return []() {
+		SDLApplication::newScene<ChestScene>();
+	};
 }

--- a/Game/Game/src/node/ChestNode.h
+++ b/Game/Game/src/node/ChestNode.h
@@ -8,8 +8,10 @@ class ChestScene;
 class ChestNode : public Node {
 	friend Node;
 private:
+	// Constructora, recibe posición del nodo en el mapa
 	ChestNode(Vector2D const& pos);
 public:
+	// Devuelve un CallBack que abre la escena de cofre
 	virtual CallBack loadNode() const;
 };
 

--- a/Game/Game/src/node/ChestNode.h
+++ b/Game/Game/src/node/ChestNode.h
@@ -10,7 +10,7 @@ class ChestNode : public Node {
 private:
 	ChestNode(Vector2D const& pos);
 public:
-	virtual CallBack* loadNode() const;
+	virtual CallBack loadNode() const;
 };
 
 #endif // !CHESTNODE_H_

--- a/Game/Game/src/node/EventNode.cpp
+++ b/Game/Game/src/node/EventNode.cpp
@@ -1,8 +1,10 @@
 #include "EventNode.h"
 #include "../core/SDLApplication.h"
 
+// Constructora, recibe posición del nodo en el mapa
 EventNode::EventNode(Vector2D const& pos) : Node(EVENT_NODE_TEXTURE_KEY, pos) {}
 
+// Devuelve un CallBack que abre la escena de evento
 CallBack EventNode::loadNode() const {
 	return []() {
 		SDLApplication::newScene<MainMenuScene>();

--- a/Game/Game/src/node/EventNode.cpp
+++ b/Game/Game/src/node/EventNode.cpp
@@ -1,7 +1,10 @@
 #include "EventNode.h"
+#include "../core/SDLApplication.h"
 
 EventNode::EventNode(Vector2D const& pos) : Node(EVENT_NODE_TEXTURE_KEY, pos) {}
 
-CallBack* EventNode::loadNode() const {
-	return MapScene::exit;
+CallBack EventNode::loadNode() const {
+	return []() {
+		SDLApplication::newScene<MainMenuScene>();
+	};
 }

--- a/Game/Game/src/node/EventNode.h
+++ b/Game/Game/src/node/EventNode.h
@@ -7,8 +7,10 @@
 class EventNode : public Node {
 	friend Node;
 private:
+	// Constructora, recibe posición del nodo en el mapa
 	EventNode(Vector2D const& pos);
 public:
+	// Devuelve un CallBack que abre la escena de evento
 	virtual CallBack loadNode() const;
 };
 

--- a/Game/Game/src/node/EventNode.h
+++ b/Game/Game/src/node/EventNode.h
@@ -9,7 +9,7 @@ class EventNode : public Node {
 private:
 	EventNode(Vector2D const& pos);
 public:
-	virtual CallBack* loadNode() const;
+	virtual CallBack loadNode() const;
 };
 
 #endif // !EVENTNODE_H_

--- a/Game/Game/src/node/Node.cpp
+++ b/Game/Game/src/node/Node.cpp
@@ -6,8 +6,8 @@
 #include "EventNode.h"
 
 vector<Node*> Node::nodeMap = vector<Node*>();
-vector<Node*>* Node::unlockedNodes = nullptr;
 vector<Node*> Node::initialNodes = vector<Node*>();
+vector<Node*>& Node::unlockedNodes = initialNodes;
 
 // Constructora, recibe la clave de la textura
 Node::Node(string tKey, Vector2D const& pos) : state(_LOCKED_NODE), nextNodes(), textureKey(tKey), position(pos) {
@@ -30,11 +30,11 @@ void Node::unlock() {
 
 // Desbloquea los siguientes nodos y bloquea los nodos que estuvieran desbloqueados
 void Node::unlockNextNodes() {
-	for (Node* node : *unlockedNodes) {
+	for (Node* node : unlockedNodes) {
 		node->lock();
 	}
 
-	unlockedNodes = &nextNodes;
+	unlockedNodes = nextNodes;
 	for (Node* node : nextNodes) {
 		node->unlock();
 	}
@@ -61,9 +61,6 @@ void Node::complete() {
 
 // Inicializa el mapa completo de Nodos
 void Node::initializeNodeMap() {
-	// crear vector con los niveles iniciales y asignarlos al puntero de desbloqueados
-	unlockedNodes = &initialNodes;
-
 	// Crear los nodos (con unos iniciales desbloqueados)
 	(new BattleNode({NODE_LEVEL_X[0], NODE_LEVEL_Y[0]}))->unlock();
 	(new BattleNode({ NODE_LEVEL_X[1], NODE_LEVEL_Y[0] }))->unlock();

--- a/Game/Game/src/node/Node.h
+++ b/Game/Game/src/node/Node.h
@@ -4,15 +4,13 @@
 
 #include <iostream>
 #include <vector>
-#include <functional>
-#include "../scenes/MapScene.h"
 #include "../components/ButtonComponent.h"
 using namespace std;
 
 enum battleType;
 
 enum nodeState {
-	_LOCKED_NODE = 0, // cleon says: "por si acaso" time
+	_LOCKED_NODE,
 	_UNLOCKED_NODE,
 	_COMPLETED_NODE
 };
@@ -45,15 +43,13 @@ public:
 	// Cambia el estado a completado y desbloquea los siguientes nodos
 	void complete();
 	// Carga el nodo correspondiente
-	virtual CallBack* loadNode() const = 0;
+	virtual CallBack loadNode() const = 0;
 	// Devuelve la clave de la textura del nodo
 	inline virtual string getTextureKey() const { return textureKey; }
 	// Devuelve la posición asignada al nodo
 	inline const Vector2D& getPosition() const { return position; }
 	// Devuelve un puntero al estado del nodo
-	inline const nodeState* getState() const { return &state; }
-	// Devuelve un iterador al tipo de batalla del nodo
-	virtual list<battleType>::iterator* getIt() { return nullptr; }
+	inline const nodeState& getState() const { return state; }
 
 	// MÉTODOS ESTÁTICOS
 	// Inicializa el mapa completo de Nodos

--- a/Game/Game/src/node/Node.h
+++ b/Game/Game/src/node/Node.h
@@ -23,6 +23,7 @@ private:
 	string textureKey;
 	Vector2D position;
 
+	// Mapa de todos los nodos
 	static vector<Node*> nodeMap;
 	static vector<Node*> initialNodes;
 	static vector<Node*>& unlockedNodes; // cleon says: hay demasiadas cosas extrañas aquí como para comentarlo.
@@ -43,7 +44,7 @@ public:
 	void addToNextNodes(Node* const& node);
 	// Cambia el estado a completado y desbloquea los siguientes nodos
 	void complete();
-	// Carga el nodo correspondiente
+	// Devuelve un CallBack distinto para cada tipo de nodo
 	virtual CallBack loadNode() const = 0;
 	// Devuelve la clave de la textura del nodo
 	inline virtual string getTextureKey() const { return textureKey; }

--- a/Game/Game/src/node/Node.h
+++ b/Game/Game/src/node/Node.h
@@ -4,7 +4,8 @@
 
 #include <iostream>
 #include <vector>
-#include "../components/ButtonComponent.h"
+#include "../components/ecs.h"
+#include "../data/constants.h"
 using namespace std;
 
 enum battleType;
@@ -24,7 +25,7 @@ private:
 
 	static vector<Node*> nodeMap;
 	static vector<Node*> initialNodes;
-	static vector<Node*>* unlockedNodes; // cleon says: hay demasiadas cosas extrañas aquí como para comentarlo.
+	static vector<Node*>& unlockedNodes; // cleon says: hay demasiadas cosas extrañas aquí como para comentarlo.
 	
 	// Asigna el estado del nodo a bloqueado
 	void lock();

--- a/Game/Game/src/node/ShopNode.cpp
+++ b/Game/Game/src/node/ShopNode.cpp
@@ -1,8 +1,10 @@
 #include "ShopNode.h"
 #include "../core/SDLApplication.h"
 
+// Constructora, recibe posición del nodo en el mapa
 ShopNode::ShopNode(Vector2D const& pos) : Node(SHOP_NODE_TEXTURE_KEY, pos) {}
 
+// Devuelve un CallBack que abre la escena de tienda
 CallBack ShopNode::loadNode() const {
 	return []() {
 		SDLApplication::newScene<ShopScene>();

--- a/Game/Game/src/node/ShopNode.cpp
+++ b/Game/Game/src/node/ShopNode.cpp
@@ -1,7 +1,10 @@
 #include "ShopNode.h"
+#include "../core/SDLApplication.h"
 
 ShopNode::ShopNode(Vector2D const& pos) : Node(SHOP_NODE_TEXTURE_KEY, pos) {}
 
-CallBack* ShopNode::loadNode() const {
-	return MapScene::shop;
+CallBack ShopNode::loadNode() const {
+	return []() {
+		SDLApplication::newScene<ShopScene>();
+	};
 }

--- a/Game/Game/src/node/ShopNode.h
+++ b/Game/Game/src/node/ShopNode.h
@@ -8,8 +8,10 @@ class ShopScene;
 class ShopNode : public Node {
 	friend Node;
 private:
+	// Constructora, recibe posición del nodo en el mapa
 	ShopNode(Vector2D const& pos);
 public:
+	// Devuelve un CallBack que abre la escena de tienda
 	virtual CallBack loadNode() const;
 };
 

--- a/Game/Game/src/node/ShopNode.h
+++ b/Game/Game/src/node/ShopNode.h
@@ -10,7 +10,7 @@ class ShopNode : public Node {
 private:
 	ShopNode(Vector2D const& pos);
 public:
-	virtual CallBack* loadNode() const;
+	virtual CallBack loadNode() const;
 };
 
 #endif // !SHOPNODE_H_

--- a/Game/Game/src/scenes/MapScene.cpp
+++ b/Game/Game/src/scenes/MapScene.cpp
@@ -7,16 +7,3 @@ MapScene::MapScene() : GameState(), nodeMap(Node::getNodeMap()) {
 		addGameObject<NodeButton>(node, (*node)->loadNode());
 	}
 }
-
-// Abre la escena de shop
-void MapScene::shop() {
-	SDLApplication::newScene<ShopScene>();
-}
-// Abre la escena de chest
-void MapScene::chest() {
-	SDLApplication::newScene<ChestScene>();
-}
-// Vuelve a la escena de menú principal
-void MapScene::exit() {
-	SDLApplication::newScene<MainMenuScene>();
-}

--- a/Game/Game/src/scenes/MapScene.h
+++ b/Game/Game/src/scenes/MapScene.h
@@ -13,12 +13,6 @@ private:
 	vector<Node*> const& nodeMap;
 public:
 	MapScene();
-	// Abre la escena de shop
-	static void shop();
-	// Abre la escena de chest
-	static void chest();
-	// Vuelve a la escena de menú principal
-	static void exit();
 };
 
 #endif


### PR DESCRIPTION
- Ya no dan asco los nodos de batalla y no tienen punteros a iteradores
- Tipo CallBack movido a ecs.h y ahora puede guardar funciones lambda con capturas
- Todos los CallBack de los nodos son lambda, no métodos estáticos de MapScene
- Punteros extraños cambiados a referencias